### PR TITLE
[Chore] importpath and doc cleanups

### DIFF
--- a/service/controller/pdf_generation/pdf_generation.go
+++ b/service/controller/pdf_generation/pdf_generation.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Zomato/espresso/lib/pkg/templatestore"
-	"github.com/Zomato/espresso/lib/pkg/utils"
+	"github.com/Zomato/espresso/lib/templatestore"
+	"github.com/Zomato/espresso/lib/utils"
 	"github.com/Zomato/espresso/service/internal/pkg/httppkg"
 	"github.com/Zomato/espresso/service/internal/service/generateDoc"
 	"github.com/spf13/viper"

--- a/service/controller/pdf_generation/register.go
+++ b/service/controller/pdf_generation/register.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/Zomato/espresso/lib/pkg/s3"
-	"github.com/Zomato/espresso/lib/pkg/templatestore"
+	"github.com/Zomato/espresso/lib/s3"
+	"github.com/Zomato/espresso/lib/templatestore"
 	"github.com/spf13/viper"
 )
 

--- a/service/go.mod
+++ b/service/go.mod
@@ -3,7 +3,7 @@ module github.com/Zomato/espresso/service
 go 1.22.4
 
 require (
-	github.com/Zomato/espresso/lib v0.0.0-20250313111013-d0adec53d9e3
+	github.com/Zomato/espresso/lib v0.0.0-20250316142812-954ffe9efdb5
 	github.com/go-rod/rod v0.116.2
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0

--- a/service/go.sum
+++ b/service/go.sum
@@ -1,7 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/Zomato/espresso/lib v0.0.0-20250313111013-d0adec53d9e3 h1:06CwRMq6P7SkuhmWyPkVInCUGn73OWogQvkVvJupfpw=
-github.com/Zomato/espresso/lib v0.0.0-20250313111013-d0adec53d9e3/go.mod h1:kLwZ8Pdcx3k5UepIeNTCTKT0+/T78gYLmXFO9O+Ew54=
+github.com/Zomato/espresso/lib v0.0.0-20250316142812-954ffe9efdb5 h1:EV7367gnsGq9gCKTa2CXfmZoo9bMkHG4k9fSUqKkxYA=
+github.com/Zomato/espresso/lib v0.0.0-20250316142812-954ffe9efdb5/go.mod h1:kLwZ8Pdcx3k5UepIeNTCTKT0+/T78gYLmXFO9O+Ew54=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=

--- a/service/internal/service/generateDoc/generatePdf.go
+++ b/service/internal/service/generateDoc/generatePdf.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Zomato/espresso/lib/pkg/browser_manager"
-	"github.com/Zomato/espresso/lib/pkg/certmanager"
-	"github.com/Zomato/espresso/lib/pkg/renderer"
-	"github.com/Zomato/espresso/lib/pkg/signer"
-	"github.com/Zomato/espresso/lib/pkg/templatestore"
-	"github.com/Zomato/espresso/lib/pkg/workerpool"
+	"github.com/Zomato/espresso/lib/browser_manager"
+	"github.com/Zomato/espresso/lib/certmanager"
+	"github.com/Zomato/espresso/lib/renderer"
+	"github.com/Zomato/espresso/lib/signer"
+	"github.com/Zomato/espresso/lib/templatestore"
+	"github.com/Zomato/espresso/lib/workerpool"
 	"github.com/spf13/viper"
 
 	"github.com/go-rod/rod/lib/proto"
@@ -117,7 +117,6 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 		FilePath:   req.OutputTemplatePath,
 		FileS3Path: req.OutputTemplatePath,
 	}
-
 	// Upload the streaming data
 	resp, err := (*fileStoreAdapter).PutDocument(ctx, docReq, &pdfReader)
 	if err != nil {

--- a/service/main.go
+++ b/service/main.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Zomato/espresso/lib/pkg/browser_manager"
+	"github.com/Zomato/espresso/lib/browser_manager"
 
-	"github.com/Zomato/espresso/lib/pkg/workerpool"
+	"github.com/Zomato/espresso/lib/workerpool"
 	"github.com/Zomato/espresso/service/controller/pdf_generation"
 	"github.com/Zomato/espresso/service/internal/pkg/viperpkg"
 	"github.com/spf13/viper"


### PR DESCRIPTION
This pull request includes updates to the `docs/Integration.md` file and some import path changes in several Go files. The changes aim to improve the documentation for setting up dependencies and initializing the PDF generation process, as well as to update the import paths for better organization.

Documentation updates:

* Added a new section for setting up dependencies using a Dockerfile in `docs/Integration.md`.
* Updated the instructions for initializing the browser and worker pool before PDF generation in `docs/Integration.md`.
* Renamed and reorganized sections for PDF generation and signing in `docs/Integration.md`. [[1]](diffhunk://#diff-214b5322d56dae669215c05f248188d30e6ee132eb272f9fe57b478aaab5e425L93-R191) [[2]](diffhunk://#diff-214b5322d56dae669215c05f248188d30e6ee132eb272f9fe57b478aaab5e425L111-R202)

Import path changes:

* Updated import paths from `github.com/Zomato/espresso/lib/pkg/*` to `github.com/Zomato/espresso/lib/*` in several files:
  * `service/controller/pdf_generation/pdf_generation.go`
  * `service/controller/pdf_generation/register.go`
  * `service/internal/service/generateDoc/generatePdf.go`
  * `service/main.go`

Dependency version update:

* Updated the version of `github.com/Zomato/espresso/lib` in `service/go.mod`.