### PR TITLE
fix(espresso): updated golang version to 1.23, updated docs

### DIFF
--- a/docs/Integration.md
+++ b/docs/Integration.md
@@ -254,7 +254,7 @@ pdf, err := renderer.GetHtmlPdf(ctx, input, nil) // Note: nil adapter
 ### 2. Disk Storage
 ```go
 
-diskAdapter, err := templatestore.TemplateStorageAdapterFactory(templatestore.TemplateStorageConfig{
+diskAdapter, err := templatestore.TemplateStorageAdapterFactory(templatestore.StorageConfig{
     StorageType: "disk",
 })
 input := &renderer.GetHtmlPdfInput{
@@ -279,7 +279,7 @@ Note: You can use your own implementation to replace the spf13/viper package
 //   accessKeyID: "your-key"
 //   secretAccessKey: "your-secret"
 
-s3Adapter, err := templatestore.TemplateStorageAdapterFactory(templatestore.TemplateStorageConfig{
+s3Adapter, err := templatestore.TemplateStorageAdapterFactory(templatestore.StorageConfig{
     StorageType: "s3",
     S3Config   :  &s3.Config{
         // your configuration
@@ -315,7 +315,7 @@ pdf, err := renderer.GetHtmlPdf(ctx, input, &s3Adapter)
 ### 4. MySQL Storage
 ```go
 
-mysqlAdapter, err := templatestore.TemplateStorageAdapterFactory(templatestore.TemplateStorageConfig{
+mysqlAdapter, err := templatestore.TemplateStorageAdapterFactory(templatestore.StorageConfig{
     StorageType: "mysql",
     MysqlDSN: "your mysql dsn connection string"
 })

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/Zomato/espresso/lib
 
-go 1.22.4
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3

--- a/lib/templatestore/templatestore.go
+++ b/lib/templatestore/templatestore.go
@@ -39,7 +39,7 @@ func TemplateStorageAdapterFactory(conf *StorageConfig) (StorageAdapter, error) 
 		return &DiskTemplateStorage{}, nil
 	case StorageAdapterTypeS3:
 		if conf == nil {
-			return nil, errors.New("templateStorageConfig is required")
+			return nil, errors.New("StorageConfig is required")
 		}
 		if conf.S3Config == nil {
 			return nil, errors.New("S3 configuration is required")

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.4-bullseye
+FROM --platform=$BUILDPLATFORM golang:1.23.0-bullseye
 
 WORKDIR /app/espresso/
 

--- a/service/go.mod
+++ b/service/go.mod
@@ -2,8 +2,6 @@ module github.com/Zomato/espresso/service
 
 go 1.23.0
 
-toolchain go1.23.1
-
 require (
 	github.com/Zomato/espresso/lib v0.0.0-20250422055733-4aa4a50d2b3b
 	github.com/go-rod/rod v0.116.2


### PR DESCRIPTION
This pull request includes updates to improve consistency in configuration naming, upgrade the Go version across the project, and enhance error messaging. Below is a summary of the most important changes:

### Configuration and Naming Consistency:
* Replaced `TemplateStorageConfig` with `StorageConfig` in multiple examples in `docs/Integration.md` for disk, S3, and MySQL storage to align with updated naming conventions. [[1]](diffhunk://#diff-214b5322d56dae669215c05f248188d30e6ee132eb272f9fe57b478aaab5e425L257-R257) [[2]](diffhunk://#diff-214b5322d56dae669215c05f248188d30e6ee132eb272f9fe57b478aaab5e425L282-R282) [[3]](diffhunk://#diff-214b5322d56dae669215c05f248188d30e6ee132eb272f9fe57b478aaab5e425L318-R318)

### Go Version Upgrade:
* Updated the Go version from `1.22.4` to `1.23.0` in `lib/go.mod` and `service/Dockerfile` to use the latest features and improvements. [[1]](diffhunk://#diff-8bacfb2c40d8c2cda88a1076ed5887c2f848bfe9da623592f97e5b05aab095d2L3-R3) [[2]](diffhunk://#diff-6705ab7b257c4306d9ebd01a75b17c7169775917081cb55ddc0877069936735eL1-R1)
* Removed the `toolchain` directive and ensured `go 1.23.0` is specified in `service/go.mod`.

### Error Messaging Improvements:
* Improved error message clarity by changing "templateStorageConfig is required" to "StorageConfig is required" in `lib/templatestore/templatestore.go`.