### PR TITLE
fix: timestamp not displayed in logs & added log to service layer

### DIFF
--- a/service/controller/pdf_generation/pdf_generation.go
+++ b/service/controller/pdf_generation/pdf_generation.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
 
+	log "github.com/Zomato/espresso/lib/logger"
 	"github.com/Zomato/espresso/lib/templatestore"
 	"github.com/Zomato/espresso/lib/utils"
 	"github.com/Zomato/espresso/service/internal/pkg/httppkg"
@@ -25,7 +25,7 @@ func (s *EspressoService) GeneratePDF(w http.ResponseWriter, r *http.Request) {
 	// Read and parse the request body
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("Error reading request body: %v", err)
+		log.Logger.Error(ctx, "Error reading request body: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to read request body", http.StatusBadRequest)
 		return
 	}
@@ -33,13 +33,13 @@ func (s *EspressoService) GeneratePDF(w http.ResponseWriter, r *http.Request) {
 
 	// Parse the request JSON
 	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		log.Printf("Error parsing JSON: %v", err)
+		log.Logger.Error(ctx, "Error parsing JSON: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to parse JSON request", http.StatusBadRequest)
 		return
 	}
 
 	reqId := utils.GenerateUniqueID(ctx)
-	fmt.Println("GeneratePDF called, req id :: ", reqId)
+	log.Logger.Info(ctx, "GeneratePDF called :: ", map[string]any{"req_id": reqId})
 
 	generatePdfReq := &generateDoc.PDFDto{
 		ReqId:              reqId,
@@ -58,7 +58,7 @@ func (s *EspressoService) GeneratePDF(w http.ResponseWriter, r *http.Request) {
 
 	err = generateDoc.GeneratePDF(ctx, generatePdfReq, s.TemplateStorageAdapter, s.FileStorageAdapter)
 	if err != nil {
-		fmt.Println("error in generating pdf :: ", err)
+		log.Logger.Error(ctx, "error in generating pdf :: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to generate PDF: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -73,7 +73,7 @@ func (s *EspressoService) GeneratePDF(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(startTime)
-	fmt.Printf("generated %s pdf in :: %s\n", reqId, duration)
+	log.Logger.Info(ctx, "generated pdf :: ", map[string]any{"req_id": reqId, "duration": duration})
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(responseData)
@@ -84,12 +84,12 @@ func (s *EspressoService) GeneratePDFStream(w http.ResponseWriter, r *http.Reque
 	startTime := time.Now()
 	reqId := utils.GenerateUniqueID(ctx)
 
-	fmt.Println("GeneratePDFStream called, req id :: ", reqId)
+	log.Logger.Info(ctx, "GeneratePDFStream called :: ", map[string]any{"req_id": reqId})
 
 	// Read and parse the request body
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("Error reading request body: %v", err)
+		log.Logger.Error(ctx, "Error reading request body: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to read request body", http.StatusBadRequest)
 		return
 	}
@@ -98,7 +98,7 @@ func (s *EspressoService) GeneratePDFStream(w http.ResponseWriter, r *http.Reque
 	// Parse the request JSON
 	var pdfReq PDFRequest
 	if err := json.Unmarshal(bodyBytes, &pdfReq); err != nil {
-		log.Printf("Error parsing JSON: %v", err)
+		log.Logger.Error(ctx, "Error parsing JSON: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to parse JSON request", http.StatusBadRequest)
 		return
 	}
@@ -151,7 +151,7 @@ func (s *EspressoService) GeneratePDFStream(w http.ResponseWriter, r *http.Reque
 		StorageType: "stream",
 	})
 	if err != nil {
-		fmt.Println("error in getting file storage adapter :: ", err)
+		log.Logger.Error(ctx, "error in getting file storage adapter :: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to get file storage adapter: "+err.Error(), http.StatusExpectationFailed)
 		return
 	}
@@ -160,13 +160,13 @@ func (s *EspressoService) GeneratePDFStream(w http.ResponseWriter, r *http.Reque
 		MysqlDSN:    viper.GetString("mysql.dsn"),
 	})
 	if err != nil {
-		fmt.Println("error in getting file storage adapter :: ", err)
+		log.Logger.Error(ctx, "error in getting file storage adapter :: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to get file storage adapter: "+err.Error(), http.StatusExpectationFailed)
 		return
 	}
 	err = generateDoc.GeneratePDF(ctx, generatePdfReq, &templateStorageAdapter, &fileStorageAdapter)
 	if err != nil {
-		fmt.Println("error in generating pdf stream:: ", err)
+		log.Logger.Error(ctx, "error in generating pdf stream:: %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to generate PDF stream: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -199,12 +199,12 @@ func (s *EspressoService) GeneratePDFStream(w http.ResponseWriter, r *http.Reque
 		// Write the PDF data
 		_, err = w.Write(generatePdfReq.OutputFileBytes)
 		if err != nil {
-			fmt.Println("error writing pdf stream :: ", err)
+			log.Logger.Error(ctx, "error writing pdf stream :: %v", err, nil)
 			httppkg.RespondWithError(w, "Failed to write PDF stream: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		duration := time.Since(startTime)
-		fmt.Printf("generated %s pdf stream in :: %s\n", reqId, duration)
+		log.Logger.Info(ctx, "generated pdf stream :: ", map[string]any{"req_id": reqId, "duration": duration})
 
 		return
 	} else {
@@ -220,13 +220,14 @@ func (s *EspressoService) SignPDF(w http.ResponseWriter, r *http.Request) {
 	req := &SignPDFRequest{}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		fmt.Println("error decoding request body :: ", err)
+		log.Logger.Error(ctx, "error decoding request body :: %v", err, nil)
 		httppkg.RespondWithError(w, "Error decoding request body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	reqId := utils.GenerateUniqueID(ctx)
-	fmt.Println("GeneratePDF called, req id :: ", reqId)
+	log.Logger.Info(ctx, "GeneratePDF called :: ", map[string]any{"req_id": reqId})
+
 	signPDFDto := &generateDoc.SignPDFDto{
 		ReqId:          reqId,
 		InputFilePath:  req.InputFilePath,
@@ -237,13 +238,14 @@ func (s *EspressoService) SignPDF(w http.ResponseWriter, r *http.Request) {
 		signPDFDto.SignParams = req.SignParams
 	} else {
 		err := fmt.Errorf("signPdf param is not true in the request")
-		fmt.Println("error in signing pdf :: ", err)
+		log.Logger.Error(ctx, "error in signing pdf :: : %v", err, nil)
+
 		httppkg.RespondWithError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	err := generateDoc.SignPDF(ctx, signPDFDto, s.FileStorageAdapter)
 	if err != nil {
-		fmt.Println("error in signing pdf :: ", err)
+		log.Logger.Error(ctx, "error in signing pdf :: : %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to sign PDF: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -266,12 +268,12 @@ func (s *EspressoService) GetAllTemplates(w http.ResponseWriter, r *http.Request
 	startTime := time.Now()
 
 	reqId := utils.GenerateUniqueID(ctx)
-	fmt.Println("GetAllTemplates called, req id :: ", reqId)
+	log.Logger.Info(ctx, "GetAllTemplates called :: ", map[string]any{"req_id": reqId})
 
 	// Get templates from the storage adapter
 	templates, err := (*s.TemplateStorageAdapter).ListTemplates(ctx)
 	if err != nil {
-		fmt.Println("error listing templates :: ", err)
+		log.Logger.Error(ctx, "error listing templates :: : %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to list templates: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -308,7 +310,7 @@ func (s *EspressoService) GetAllTemplates(w http.ResponseWriter, r *http.Request
 	}
 
 	duration := time.Since(startTime)
-	fmt.Printf("listed %d templates in :: %s\n", len(templateDataList), duration)
+	log.Logger.Info(ctx, "listed templates :: ", map[string]any{"length": len(templateDataList), "duration": duration})
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(responseData)
@@ -318,8 +320,8 @@ func (s *EspressoService) GetTemplateById(w http.ResponseWriter, r *http.Request
 
 	templateID := r.URL.Query().Get("template_id")
 	if templateID == "" {
-		fmt.Println("template id is required")
-		httppkg.RespondWithError(w, "Template ID is required", http.StatusBadRequest)
+		log.Logger.Error(ctx, "template id is required ", nil, nil)
+		httppkg.RespondWithError(w, "template id is required", http.StatusBadRequest)
 		return
 	}
 
@@ -327,7 +329,7 @@ func (s *EspressoService) GetTemplateById(w http.ResponseWriter, r *http.Request
 		TemplateUUID: templateID,
 	})
 	if err != nil {
-		fmt.Println("error getting template content :: ", err)
+		log.Logger.Error(ctx, "error getting template content :: : %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to get template content: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -357,19 +359,20 @@ func (s *EspressoService) CreateTemplate(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 	// decode request body
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		fmt.Println("error decoding request body :: ", err)
+		log.Logger.Error(ctx, "error decoding request body :: : %v", err, nil)
+
 		httppkg.RespondWithError(w, "Error decoding request body: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 	// Validate request
 	if req.TemplateName == "" {
-		fmt.Println("template name is required")
+		log.Logger.Error(ctx, "template name is required ", nil, nil)
 		httppkg.RespondWithError(w, "Template name is required", http.StatusBadRequest)
 		return
 	}
 
 	if req.TemplateHtml == "" {
-		fmt.Println("template html is required")
+		log.Logger.Error(ctx, "template html is required ", nil, nil)
 		httppkg.RespondWithError(w, "Template HTML is required", http.StatusBadRequest)
 		return
 	}
@@ -389,7 +392,7 @@ func (s *EspressoService) CreateTemplate(w http.ResponseWriter, r *http.Request)
 
 	templateId, err := (*s.TemplateStorageAdapter).CreateTemplate(ctx, createReq)
 	if err != nil {
-		fmt.Printf("error creating template: %v\n", err)
+		log.Logger.Error(ctx, "error creating template :: : %v", err, nil)
 		httppkg.RespondWithError(w, "Failed to create template: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/service/internal/service/generateDoc/generatePdf.go
+++ b/service/internal/service/generateDoc/generatePdf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Zomato/espresso/lib/workerpool"
 	"github.com/spf13/viper"
 
+	log "github.com/Zomato/espresso/lib/logger"
 	"github.com/go-rod/rod/lib/proto"
 )
 
@@ -91,7 +92,7 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 	defer pdf.Close()
 
 	duration := time.Since(startTime)
-	fmt.Println("pdf stream received at :: ", duration)
+	log.Logger.Info(ctx, "pdf stream received :: ", map[string]any{"duration": duration})
 
 	duration = time.Since(startTime)
 
@@ -111,7 +112,8 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 	} else {
 		pdfReader = pdf
 	}
-	fmt.Println("starting upload :: ", duration)
+	log.Logger.Info(ctx, "starting upload :: ", map[string]any{"duration": duration})
+
 	// Use the storage adapter to store the PDF
 	docReq := &templatestore.PostDocumentRequest{
 		FilePath:   req.OutputTemplatePath,
@@ -127,7 +129,7 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 	}
 
 	duration = time.Since(startTime)
-	fmt.Println("uploaded to storage at :: ", duration)
+	log.Logger.Info(ctx, "uploaded to storage :: ", map[string]any{"duration": duration})
 
 	return nil
 }
@@ -192,7 +194,8 @@ func getViewPort(viewPort *ViewportConfig) *browser_manager.ViewportConfig {
 func SignPDF(ctx context.Context, req *SignPDFDto, fileStoreAdapter *templatestore.StorageAdapter) error {
 
 	reqId := req.ReqId
-	fmt.Println("SignPDF called, req id :: ", reqId)
+	log.Logger.Info(ctx, "SignPDF called ", map[string]any{"req id": reqId})
+
 	// get input file stream
 	freader, err := (*fileStoreAdapter).GetDocument(ctx, &templatestore.GetDocumentRequest{
 		FilePath:       req.InputFilePath,

--- a/service/internal/service/generateDoc/generatePdf.go
+++ b/service/internal/service/generateDoc/generatePdf.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Zomato/espresso/lib/workerpool"
 	"github.com/spf13/viper"
 
-	log "github.com/Zomato/espresso/lib/logger"
+	svcUtils "github.com/Zomato/espresso/service/utils"
 	"github.com/go-rod/rod/lib/proto"
 )
 
@@ -92,7 +92,7 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 	defer pdf.Close()
 
 	duration := time.Since(startTime)
-	log.Logger.Info(ctx, "pdf stream received :: ", map[string]any{"duration": duration})
+	svcUtils.Logger.Info(ctx, "pdf stream received :: ", map[string]any{"duration": duration})
 
 	duration = time.Since(startTime)
 
@@ -112,7 +112,7 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 	} else {
 		pdfReader = pdf
 	}
-	log.Logger.Info(ctx, "starting upload :: ", map[string]any{"duration": duration})
+	svcUtils.Logger.Info(ctx, "starting upload :: ", map[string]any{"duration": duration})
 
 	// Use the storage adapter to store the PDF
 	docReq := &templatestore.PostDocumentRequest{
@@ -129,7 +129,7 @@ func GeneratePDF(ctx context.Context, req *PDFDto, templateStoreAdapter *templat
 	}
 
 	duration = time.Since(startTime)
-	log.Logger.Info(ctx, "uploaded to storage :: ", map[string]any{"duration": duration})
+	svcUtils.Logger.Info(ctx, "uploaded to storage :: ", map[string]any{"duration": duration})
 
 	return nil
 }
@@ -194,7 +194,7 @@ func getViewPort(viewPort *ViewportConfig) *browser_manager.ViewportConfig {
 func SignPDF(ctx context.Context, req *SignPDFDto, fileStoreAdapter *templatestore.StorageAdapter) error {
 
 	reqId := req.ReqId
-	log.Logger.Info(ctx, "SignPDF called ", map[string]any{"req id": reqId})
+	svcUtils.Logger.Info(ctx, "SignPDF called ", map[string]any{"req id": reqId})
 
 	// get input file stream
 	freader, err := (*fileStoreAdapter).GetDocument(ctx, &templatestore.GetDocumentRequest{

--- a/service/main.go
+++ b/service/main.go
@@ -26,10 +26,10 @@ func main() {
 	logger.Initialize(zeroLog)
 
 	templateStorageType := viper.GetString("template_storage.storage_type")
-	logger.Logger.Info(ctx, "Template storage type ", map[string]any{"type": templateStorageType})
+	zeroLog.Info(ctx, "Template storage type ", map[string]any{"type": templateStorageType})
 
 	fileStorageType := viper.GetString("file_storage.storage_type")
-	logger.Logger.Info(ctx, "File storage type ", map[string]any{"type": fileStorageType})
+	zeroLog.Info(ctx, "File storage type ", map[string]any{"type": fileStorageType})
 
 	tabpool := viper.GetInt("browser.tab_pool")
 	if err := browser_manager.Init(ctx, tabpool); err != nil {
@@ -55,7 +55,7 @@ func main() {
 
 	// your implementation
 
-	logger.Logger.Info(ctx, "Server terminated", nil)
+	zeroLog.Info(ctx, "Server terminated", nil)
 }
 
 func initializeWorkerPool(workerCount int, workerTimeout int) {

--- a/service/main.go
+++ b/service/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -26,8 +25,11 @@ func main() {
 	zeroLog := utils.NewZeroLogger()
 	logger.Initialize(zeroLog)
 
-	log.Printf("Template storage type: %s", viper.GetString("template_storage.storage_type"))
-	log.Printf("File storage type: %s", viper.GetString("file_storage.storage_type"))
+	templateStorageType := viper.GetString("template_storage.storage_type")
+	logger.Logger.Info(ctx, "Template storage type ", map[string]any{"type": templateStorageType})
+
+	fileStorageType := viper.GetString("file_storage.storage_type")
+	logger.Logger.Info(ctx, "File storage type ", map[string]any{"type": fileStorageType})
 
 	tabpool := viper.GetInt("browser.tab_pool")
 	if err := browser_manager.Init(ctx, tabpool); err != nil {
@@ -53,7 +55,7 @@ func main() {
 
 	// your implementation
 
-	fmt.Println("Server terminated")
+	logger.Logger.Info(ctx, "Server terminated", nil)
 }
 
 func initializeWorkerPool(workerCount int, workerTimeout int) {

--- a/service/utils/zerolog.go
+++ b/service/utils/zerolog.go
@@ -31,9 +31,9 @@ func addFields(event *zerolog.Event, fields map[string]any) *zerolog.Event {
 	for k, v := range fields {
 		if k == "time" {
 			event = event.Interface("timestamp", v)
+		} else {
+			event = event.Interface(k, v)
 		}
-
-		event = event.Interface(k, v)
 	}
 
 	return event

--- a/service/utils/zerolog.go
+++ b/service/utils/zerolog.go
@@ -1,9 +1,7 @@
 package utils
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -20,16 +18,6 @@ func NewZeroLogger() ZeroLog {
 	log.Logger = log.Output(zerolog.ConsoleWriter{
 		Out:        os.Stderr,
 		TimeFormat: time.RFC3339,
-		FormatExtra: func(m map[string]interface{}, b *bytes.Buffer) error {
-			for k, v := range m {
-				if k == "message" || k == "level" {
-					continue
-				}
-
-				_, _ = fmt.Fprintf(b, " %s=%v", k, v)
-			}
-			return nil
-		},
 	})
 
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
@@ -41,6 +29,10 @@ func NewZeroLogger() ZeroLog {
 
 func addFields(event *zerolog.Event, fields map[string]any) *zerolog.Event {
 	for k, v := range fields {
+		if k == "time" {
+			event = event.Interface("timestamp", v)
+		}
+
 		event = event.Interface(k, v)
 	}
 

--- a/service/utils/zerolog.go
+++ b/service/utils/zerolog.go
@@ -14,6 +14,10 @@ type ZeroLog struct {
 	logger zerolog.Logger
 }
 
+var (
+	Logger ZeroLog
+)
+
 func NewZeroLogger() ZeroLog {
 	log.Logger = log.Output(zerolog.ConsoleWriter{
 		Out:        os.Stderr,
@@ -22,9 +26,13 @@ func NewZeroLogger() ZeroLog {
 
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
-	return ZeroLog{
+	zeroLog := ZeroLog{
 		logger: log.Logger,
 	}
+
+	Logger = zeroLog
+
+	return zeroLog
 }
 
 func addFields(event *zerolog.Event, fields map[string]any) *zerolog.Event {

--- a/service/utils/zerolog.go
+++ b/service/utils/zerolog.go
@@ -29,11 +29,7 @@ func NewZeroLogger() ZeroLog {
 
 func addFields(event *zerolog.Event, fields map[string]any) *zerolog.Event {
 	for k, v := range fields {
-		if k == "time" {
-			event = event.Interface("timestamp", v)
-		} else {
-			event = event.Interface(k, v)
-		}
+		event = event.Interface(k, v)
 	}
 
 	return event


### PR DESCRIPTION
Hi @Ashish-walkingn8mare 

time was not visible because it is a built in field in zerolog. Instead of using time I've replaced it with `timestamp` with following code

```
func addFields(event *zerolog.Event, fields map[string]any) *zerolog.Event {
	for k, v := range fields {
		if k == "time" {
			event = event.Interface("timestamp", v)
		} else {
			event = event.Interface(k, v)
		}
	}

	return event
}
```

I would suggest that we should use `timestamp` in logging instead of `time` at it may collide with other libraries as well.

What do you say?