### PR TITLE
fix(makefile): updated makefile to detect docker command, updated readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: build run dev clean help
 
+
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose >/dev/null 2>&1; then echo "docker-compose"; else echo "docker compose"; fi)
+
 # Default target when just running 'make'
 all: dev
 
@@ -37,8 +40,8 @@ init:
 
 dev:
 	DOCKERFILE=service/Dockerfile \
-    docker-compose -f service/docker-compose.yml build && \
-    docker-compose -f service/docker-compose.yml up -d && \
+    $(DOCKER_COMPOSE_CMD) -f service/docker-compose.yml build && \
+    $(DOCKER_COMPOSE_CMD) -f service/docker-compose.yml up -d && \
 	open http://localhost:3000
 
 test-lib:
@@ -54,7 +57,7 @@ test: test-service test-lib
 
 # Clean up
 clean:
-	docker-compose -f service/docker-compose.yml down
+	$(DOCKER_COMPOSE_CMD) -f service/docker-compose.yml down
 	docker rmi -f docker.io/library/service-espresso-ui docker.io/localstack/localstack docker.io/library/service-espresso
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See our [Quick Start Guide](docs/QuickStart.md) for running the service using Do
 
 ## Requirements
 
-- Go 1.22+
+- Go 1.23+
 - Docker & Docker Compose (for running the complete service)
 - X.509 certificates (for PDF signing)
 


### PR DESCRIPTION
This pull request introduces a minor refactor to the `Makefile` to improve compatibility with different Docker Compose installations and updates the Go version requirement in the `README.md`. The most important changes are grouped and summarized below:

### Improvements to Docker Compose compatibility:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R3-R5): Introduced a `DOCKER_COMPOSE_CMD` variable to dynamically determine whether to use `docker-compose` or `docker compose`, ensuring compatibility across environments.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-R44): Updated the `dev`, `clean`, and other relevant targets to use the `DOCKER_COMPOSE_CMD` variable instead of hardcoding `docker-compose`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-R44) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L57-R60)

### Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30): Updated the Go version requirement from 1.22+ to 1.23+ to reflect the latest dependency requirements.